### PR TITLE
[#11][#12] [UI][Backend] As a user, when I forgot my account's password, I can retrieve it

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,29 @@
-<h2>Change your password</h2>
+<div class="modal-dialog modal-content p-4">
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+  <h2>Change your password</h2>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+    <div class="form-group">
+      <%= f.label :password, "New password" %>
+      <% if @minimum_password_length %>
+        <em>(<%= @minimum_password_length %> characters minimum)</em>
+      <% end %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", required: true, class: "form-control" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
+    <div class="form-group">
+      <%= f.label :password_confirmation, "Confirm new password" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true, class: "form-control" %>
+    </div>
 
-<%= render "devise/shared/links" %>
+    <div class="form-group">
+      <%= f.submit "Change my password", class: "form-control btn btn-primary" %>
+    </div>
+  <% end %>
+
+  <%= render "devise/shared/links" %>
+
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,18 @@
-<h2>Forgot your password?</h2>
+<div class="modal-dialog modal-content p-4">
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <h2>Forgot your password?</h2>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
+    <div class="form-group">
+      <%= f.label :email %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control", required: true %>
+    </div>
 
-<%= render "devise/shared/links" %>
+    <div class="form-group">
+      <%= f.submit "Send me reset password instructions", class: "form-control btn btn-primary" %>
+    </div>
+  <% end %>
+
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,21 +1,31 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name), class: "btn btn-outline-dark" %><br/>
+  <div class="form-group">
+    <%= link_to "Log in", new_session_path(resource_name), class: "form-control btn btn-outline-dark" %><br/>
+  </div>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name), class: "btn btn-outline-dark" %><br/>
+  <div class="form-group">
+    <%= link_to "Sign up", new_registration_path(resource_name), class: "form-control btn btn-outline-dark" %><br/>
+  </div>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <!--    <%#= link_to "Forgot your password?", new_password_path(resource_name) %><br/>-->
+  <div class="form-group">
+    <%= link_to "Forgot your password?", new_password_path(resource_name) %><br/>
+  </div>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br/>
+  <div class="form-group">
+    <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br/>
+  </div>
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br/>
+  <div class="form-group">
+    <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br/>
+  </div>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>


### PR DESCRIPTION
#11
#12

## What happened 👀

A user must be authenticated to use the application, in case they forgot the password, they can retrieve it, so we need to support forgot password feature.
 
## Insight 📝

- Backend is done by [devise](https://github.com/heartcombo/devise)
- In this pull request, I update UIs for forgot password screens.
 
## Proof Of Work 📹

**Forgot password screen**

<img width="1440" alt="Screen Shot 2021-11-23 at 11 39 46" src="https://user-images.githubusercontent.com/19943832/142973716-587db19a-e305-476b-9b10-4af92e1734a4.png">

---
**Forgot password error**

<img width="1440" alt="Screen Shot 2021-11-23 at 11 40 05" src="https://user-images.githubusercontent.com/19943832/142973713-b8a9637d-d860-468d-b0b6-f5f8b839e4e6.png">

---
**Forgot password succeed**

<img width="1440" alt="Screen Shot 2021-11-23 at 11 40 31" src="https://user-images.githubusercontent.com/19943832/142973712-a6772ccd-daf2-4971-ad0f-c5a32ab537b9.png">

---
**Email content**

<img width="1440" alt="Screen Shot 2021-11-23 at 11 40 40" src="https://user-images.githubusercontent.com/19943832/142973709-28ba13a4-f406-486f-9d68-313e1c326a7d.png">

---
**Change password screen**

<img width="1440" alt="Screen Shot 2021-11-23 at 11 45 23" src="https://user-images.githubusercontent.com/19943832/142973703-65ab33d7-39b5-4924-b26a-5612c52b6426.png">

---
**Change password succeed**

<img width="1438" alt="Screen Shot 2021-11-23 at 11 45 48" src="https://user-images.githubusercontent.com/19943832/142973696-d631e977-23f8-41cb-a4d4-4ce2dd866124.png">
