### PR TITLE
[#4] [API] As a user, when signing in with email for the first time, I can register an account

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require: 
+require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-performance
@@ -44,3 +44,6 @@ RSpec/ContextWording:
   Prefixes:
     - when
     - given
+
+RSpec/NestedGroups:
+  Max: 5

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    class RegistrationsController < Devise::RegistrationsController
+      include API::V1::ErrorHandler
+
+      skip_before_action :verify_authenticity_token
+      before_action :verify_oauth_application
+
+      def create
+        super do |user|
+          if user.persisted?
+            head :created
+          else
+            render_error(detail: user.errors.full_messages.to_sentence)
+          end
+          return
+        end
+      end
+
+      private
+
+      def verify_oauth_application
+        return if Doorkeeper::Server.new(self).client
+
+        error_description = I18n.t('doorkeeper.errors.messages.invalid_client')
+        render_error(detail: error_description, code: :invalid_client, status: :forbidden)
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/api/v1/error_handler.rb
+++ b/app/controllers/concerns/api/v1/error_handler.rb
@@ -17,6 +17,12 @@ module API
           }.delete_if { |_, value| value.blank? }
         ]
       end
+
+      def render_error(detail:, source: nil, meta: nil, status: :unprocessable_entity, code: nil)
+        errors = build_errors(detail: detail, source: source, meta: meta, code: code)
+
+        render json: { errors: errors }, status: status
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,10 @@ Rails.application.routes.draw do
         controllers tokens: 'tokens'
         skip_controllers :authorizations, :applications, :authorized_applications
       end
+
+      devise_scope :user do
+        resources :registrations, only: :create
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/registrations_controller_spec.rb
+++ b/spec/controllers/api/v1/registrations_controller_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe API::V1::RegistrationsController, type: :controller do
+  describe 'POST#create', devise_mapping: true do
+    context 'given an invalid oauth application' do
+      it 'returns forbidden status' do
+        params = { user: { email: 'test@test.test', password: 'test@test.test', password_confirmation: 'test@test.test' } }
+        post :create, params: params
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'given a valid oauth application' do
+      context 'given valid params' do
+        it 'returns created status' do
+          params = { user: { email: 'test@test.test', password: '12345678', password_confirmation: '12345678' } }
+          post :create, params: params.merge(oauth_application_params)
+
+          expect(response).to have_http_status(:created)
+        end
+
+        it 'returns an empty response body' do
+          params = { user: { email: 'test@test.test', password: '12345678', password_confirmation: '12345678' } }
+          post :create, params: params.merge(oauth_application_params)
+
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'given invalid params' do
+        context 'given no user params' do
+          it 'returns unprocessable entity status' do
+            post :create, params: oauth_application_params
+
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
+
+        context 'given no email params' do
+          it 'returns unprocessable entity status' do
+            params = { user: { password: '12345678', password_confirmation: '12345678' } }
+            post :create, params: params.merge(oauth_application_params)
+
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
+
+        context 'given an existing email' do
+          it 'returns unprocessable_entity status' do
+            Fabricate(:user, email: 'test@test.test')
+            params = { user: { email: 'test@test.test', password: '12345678', password_confirmation: '12345678' } }
+            post :create, params: params.merge(oauth_application_params)
+
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
+
+        context 'given an invalid email' do
+          it 'returns unprocessable_entity status' do
+            params = { user: { email: 'invalid_email', password: '12345678', password_confirmation: '12345678' } }
+            post :create, params: params.merge(oauth_application_params)
+
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
+
+        context 'given no password param' do
+          it 'returns unprocessable_entity status' do
+            params = { user: { email: 'test@test.test', password_confirmation: '12345678' } }
+            post :create, params: params.merge(oauth_application_params)
+
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
+
+        context 'given a short password' do
+          it 'returns unprocessable_entity status' do
+            params = { user: { email: 'test@test.test', password: '12345', password_confirmation: '12345' } }
+            post :create, params: params.merge(oauth_application_params)
+
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/registrations_controller_spec.rb
+++ b/spec/controllers/api/v1/registrations_controller_spec.rb
@@ -4,15 +4,6 @@ require 'rails_helper'
 
 RSpec.describe API::V1::RegistrationsController, type: :controller do
   describe 'POST#create', devise_mapping: true do
-    context 'given an invalid oauth application' do
-      it 'returns forbidden status' do
-        params = { user: { email: 'test@test.test', password: 'test@test.test', password_confirmation: 'test@test.test' } }
-        post :create, params: params
-
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
     context 'given a valid oauth application' do
       context 'given valid params' do
         it 'returns created status' do
@@ -84,6 +75,15 @@ RSpec.describe API::V1::RegistrationsController, type: :controller do
             expect(response).to have_http_status(:unprocessable_entity)
           end
         end
+      end
+    end
+
+    context 'given an invalid oauth application' do
+      it 'returns forbidden status' do
+        params = { user: { email: 'test@test.test', password: 'test@test.test', password_confirmation: 'test@test.test' } }
+        post :create, params: params
+
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/controllers/api/v1/tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/tokens_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe API::V1::TokensController, type: :controller do
       it 'returns success status' do
         application = Fabricate(:doorkeeper_application)
         access_token = Fabricate(:access_token, application_id: application.id)
-        post :revoke, params: { token: access_token.token, client_id: application.uid, client_secret: application.secret }
+        post :revoke, params: { token: access_token.token }.merge(oauth_application_params(application))
 
         expect(response).to have_http_status(:success)
       end

--- a/spec/support/api_authentication_helpers.rb
+++ b/spec/support/api_authentication_helpers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.configure do
+  def oauth_application_params(application = Fabricate(:doorkeeper_application))
+    {
+      client_id: application.uid,
+      client_secret: application.secret
+    }
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -4,4 +4,8 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::ControllerHelpers, type: :request
+
+  config.before(:each, devise_mapping: true) do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+  end
 end


### PR DESCRIPTION
Resolves #4

## What happened 👀

Users must be authenticated to use the application, so we need to create an API to support registering a new account.
 
## Insight 📝

- Based on `Devise::RegistrationsController`, I override the `create` function to support creating user account by API

## Proof Of Work 📹

<img width="1030" alt="Screen Shot 2022-01-14 at 16 56 57" src="https://user-images.githubusercontent.com/19943832/149496507-80e19a65-2112-49b6-9a96-946891f44e4e.png">

