### PR TITLE
[#19][#25][API] As a user, after upload a keywords file, I can see the list of keywords on the screen. [API] As a user, I can search across all the reports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,11 +14,12 @@ gem 'sidekiq' # background processing for Ruby
 gem 'bootsnap', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'i18n-js', '3.5.1' # A library to provide the I18n translations on the Javascript
 gem 'httparty' # A library to call external API
-gem 'doorkeeper' # An OAuth 2 provider.
+gem 'jsonapi-serializer' #A fast JSON: API serializer for Ruby
 
 # Authentications & Authorizations
 gem 'devise' # Authentication solution for Rails with Warden
 gem 'pundit' # Minimal authorization through OO design and pure Ruby classes
+gem 'doorkeeper' # An OAuth 2 provider.
 
 # Assets
 gem 'webpacker', '~>5.2.0' # Transpile app-like JavaScript

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,8 @@ GEM
     json_matchers (0.11.1)
       json_schema
     json_schema (0.21.0)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -515,6 +517,7 @@ DEPENDENCIES
   httparty
   i18n-js (= 3.5.1)
   json_matchers
+  jsonapi-serializer
   letter_opener
   listen (= 3.1.5)
   mini_magick

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -3,6 +3,17 @@
 module API
   module V1
     class KeywordsController < ApplicationController
+      include Pagy::Backend
+
+      def index
+        keywords_query.call
+        pagy, keywords = pagy_array(keywords_query.keywords, pagination_params)
+
+        render json: KeywordSerializer.new(keywords, meta: meta_from_pagy(pagy))
+      rescue Pagy::OverflowError
+        render status: :not_found
+      end
+
       def create
         if save_keywords
           SearchKeywordsJob.perform_later(keywords_form.keyword_ids)
@@ -25,6 +36,30 @@ module API
 
       def keywords_form
         @keywords_form ||= KeywordsForm.new(current_user)
+      end
+
+      def keywords_query
+        @keywords_query ||= KeywordsQuery.new(current_user.keywords, permitted_params)
+      end
+
+      def permitted_params
+        params.permit(:keyword)
+      end
+
+      def pagination_params
+        {
+          page: params.dig(:page, :number) || Pagy::DEFAULT[:page],
+          items: params.dig(:page, :size)
+        }
+      end
+
+      def meta_from_pagy(pagy)
+        {
+          page: pagy.page,
+          pages: pagy.pages,
+          page_size: pagy.items,
+          records: pagy.count
+        }
       end
     end
   end

--- a/app/serializers/keyword_serializer.rb
+++ b/app/serializers/keyword_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class KeywordSerializer
+  include JSONAPI::Serializer
+
+  attributes :keyword,
+             :status,
+             :ads_top_count,
+             :ads_page_count,
+             :non_ads_count,
+             :total_links_count,
+             :created_at
+
+  attribute :html, if: proc { |_, params| params[:show_detail] }
+
+  has_many :links
+end

--- a/app/serializers/link_serializer.rb
+++ b/app/serializers/link_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class LinkSerializer
+  include JSONAPI::Serializer
+
+  attributes :url,
+             :link_type,
+             :created_at
+end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -33,7 +33,7 @@
 
 # Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
 # See https://ddnexus.github.io/pagy/extras/array
-# require 'pagy/extras/array'
+require 'pagy/extras/array'
 
 # Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
 # See https://ddnexus.github.io/pagy/extras/calendar

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :keywords, only: [:create]
+      resources :keywords, only: [:index, :create]
 
       # OAuth2 Doorkeeper
       use_doorkeeper do

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -3,9 +3,106 @@
 require 'rails_helper'
 
 RSpec.describe API::V1::KeywordsController, type: :request do
-  describe 'POST#create', api_authentication: :user do
+  describe 'GET#index' do
+    context 'given a request without params' do
+      it 'returns expected status' do
+        api_sign_in
+        get :index
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns response with valid keywords' do
+        user = api_sign_in
+        %w[Hello World Keyword].each { |keyword| Fabricate(:keyword, user: user, keyword: keyword) }
+        get :index
+        keywords = JSON.parse(response.body, symbolize_names: true)[:data].map { |object| object[:attributes][:keyword] }
+
+        expect(keywords).to eq(%w[Keyword World Hello])
+      end
+
+      it 'returns expected meta data' do
+        user = api_sign_in
+        Fabricate.times(15, :keyword, user: user)
+        get :index
+        body = JSON.parse(response.body, symbolize_names: true)
+
+        expect(body[:meta]).to eq(page: 1, pages: 1, page_size: 20, records: 15)
+      end
+    end
+
+    context 'given a request with pagination params' do
+      context 'given a valid page number' do
+        it 'returns expected status' do
+          user = api_sign_in
+          Fabricate.times(4, :keyword, user: user)
+          get :index, params: { page: { number: 2, size: 2 } }
+
+          expect(response).to have_http_status(:success)
+        end
+
+        it 'returns response with valid keywords' do
+          user = api_sign_in
+          %w[Hello World Keyword].each { |keyword| Fabricate(:keyword, user: user, keyword: keyword) }
+          get :index, params: { page: { number: 2, size: 2 } }
+          keywords = JSON.parse(response.body, symbolize_names: true)[:data].map { |object| object[:attributes][:keyword] }
+
+          expect(keywords).to eq(%w[Hello])
+        end
+
+        it 'returns expected meta data' do
+          user = api_sign_in
+          Fabricate.times(20, :keyword, user: user)
+          get :index, params: { page: { number: 2, size: 2 } }
+          body = JSON.parse(response.body, symbolize_names: true)
+
+          expect(body[:meta]).to eq(page: 2, pages: 10, page_size: 2, records: 20)
+        end
+      end
+
+      context 'given an invalid page number' do
+        it 'returns not_found status' do
+          api_sign_in
+          get :index, params: { page: { number: 1000, size: 2 } }
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'given a request with search keyword params' do
+      it 'returns expected status' do
+        user = api_sign_in
+        %w[Hello World This Is Dummy Keyword List].each { |keyword| Fabricate(:keyword, user: user, keyword: keyword) }
+        get :index, params: { keyword: 'He' }
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns response with valid keywords' do
+        user = api_sign_in
+        %w[Hello World This Is Hello].each { |keyword| Fabricate(:keyword, user: user, keyword: keyword) }
+        get :index, params: { keyword: 'He' }
+        keywords = JSON.parse(response.body, symbolize_names: true)[:data].map { |object| object[:attributes][:keyword] }
+
+        expect(keywords).to eq(%w[Hello Hello])
+      end
+
+      it 'returns expected meta data' do
+        user = api_sign_in
+        %w[Hello World This Is Dummy Keyword List].each { |keyword| Fabricate(:keyword, user: user, keyword: keyword) }
+        get :index, params: { keyword: 'He' }
+        body = JSON.parse(response.body, symbolize_names: true)
+
+        expect(body[:meta]).to eq(page: 1, pages: 1, page_size: 20, records: 1)
+      end
+    end
+  end
+
+  describe 'POST#create' do
     context 'when upload a valid file' do
       it 'returns created status' do
+        api_sign_in
         post :create, params: keywords_file_params('valid_keywords.csv')
 
         expect(response).to have_http_status(:created)
@@ -14,12 +111,14 @@ RSpec.describe API::V1::KeywordsController, type: :request do
 
     context 'when upload no valid file' do
       it 'responds with alert message' do
+        api_sign_in
         post :create
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it 'returns error response with invalid message', api_authentication: :user do
+        api_sign_in
         post :create
         expected_response = { errors: [{ detail: 'Invalid file!', code: 'invalid_file' }] }
 

--- a/spec/support/api_authentication_helpers.rb
+++ b/spec/support/api_authentication_helpers.rb
@@ -1,13 +1,21 @@
 # frozen_string_literal: true
 
-RSpec.configure do |config|
-  config.before(:example, api_authentication: :user) do
-    user = Fabricate(:user)
-    application = Fabricate(:doorkeeper_application)
-    access_token = Fabricate(:access_token, resource_owner_id: user.id, application_id: application.id)
-    allow(controller).to receive(:doorkeeper_token) { access_token }
-    request.headers['Content-Type'] = 'application/json'
+module APIAuthentication
+  module OauthHelper
+    def api_sign_in
+      user = Fabricate(:user)
+      application = Fabricate(:doorkeeper_application)
+      access_token = Fabricate(:access_token, resource_owner_id: user.id, application_id: application.id)
+      allow(controller).to receive(:doorkeeper_token) { access_token }
+      request.headers['Content-Type'] = 'application/json'
+
+      user
+    end
   end
+end
+
+RSpec.configure do |config|
+  config.include APIAuthentication::OauthHelper, type: :request
 
   def oauth_application_params(application = Fabricate(:doorkeeper_application))
     {


### PR DESCRIPTION
Resolves #19
Resolves #25

## What happened 👀

- After the user uploads a keywords file, we need to show a list of keywords from that file on the screen.
- After getting all reports from the keywords list, we need to support a search feature, so the user can search and find the report they want.
 
## Insight 📝

- Create API to support getting a list of keywords of a user
- Support paging with 2 parameters: page[number], page[size]
-  Also support filter parameter: keyword

Endpoint: `{{base_url}}/api/v1/keywords?keyword=So&page[number]=1&page[size]=1`
 
## Proof Of Work 📹

<img width="1062" alt="Screen Shot 2022-01-14 at 23 21 16" src="https://user-images.githubusercontent.com/19943832/149549505-25f8f373-b18e-42c6-8b85-bf9c5925d7f0.png">

