### PR TITLE
[#22] [API] As a user, after upload the keywords file, I can see the report of each keyword

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -4,8 +4,7 @@ module API
   module V1
     class ApplicationController < ActionController::API
       include API::V1::DoorkeeperAuthentication
-      rescue_from ActiveRecord::RecordNotFound, with: :show_not_found_error
-      rescue_from Pagy::OverflowError, with: :show_not_found_error
+      rescue_from ActiveRecord::RecordNotFound, Pagy::OverflowError, with: :show_not_found_error
 
       private
 

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -4,6 +4,14 @@ module API
   module V1
     class ApplicationController < ActionController::API
       include API::V1::DoorkeeperAuthentication
+      rescue_from ActiveRecord::RecordNotFound, with: :show_not_found_error
+      rescue_from Pagy::OverflowError, with: :show_not_found_error
+
+      private
+
+      def show_not_found_error
+        render status: :not_found
+      end
     end
   end
 end

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -5,13 +5,13 @@ module API
     class KeywordsController < ApplicationController
       include Pagy::Backend
 
+      before_action :set_keyword, only: :show
+
       def index
         keywords_query.call
         pagy, keywords = pagy_array(keywords_query.keywords, pagination_params)
 
         render json: KeywordSerializer.new(keywords, meta: meta_from_pagy(pagy))
-      rescue Pagy::OverflowError
-        render status: :not_found
       end
 
       def create
@@ -28,6 +28,10 @@ module API
         end
       end
 
+      def show
+        render json: KeywordSerializer.new(@keyword, include: [:links], params: { show_detail: true })
+      end
+
       private
 
       def save_keywords
@@ -40,6 +44,10 @@ module API
 
       def keywords_query
         @keywords_query ||= KeywordsQuery.new(current_user.keywords, permitted_params)
+      end
+
+      def set_keyword
+        @keyword = current_user.keywords.find_by!(id: params[:id])
       end
 
       def permitted_params

--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -47,7 +47,7 @@ module API
       end
 
       def set_keyword
-        @keyword = current_user.keywords.find_by!(id: params[:id])
+        @keyword = current_user.keywords.find(params[:id])
       end
 
       def permitted_params

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -27,7 +27,7 @@ class KeywordsController < ApplicationController
   end
 
   def show
-    keyword = Keyword.includes(:links).find(params[:id])
+    keyword = current_user.keywords.find_by(id: params[:id])
     presenter = KeywordPresenter.new(keyword)
 
     render locals: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :keywords, only: [:index, :create]
+      resources :keywords, only: [:index, :create, :show]
 
       # OAuth2 Doorkeeper
       use_doorkeeper do

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -126,4 +126,34 @@ RSpec.describe API::V1::KeywordsController, type: :request do
       end
     end
   end
+
+  describe 'GET#show' do
+    context 'given a valid survey ID' do
+      it 'returns success status' do
+        user = api_sign_in
+        Fabricate(:keyword, user: user, id: 1)
+        get :show, params: { id: 1 }
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns the expected keyword' do
+        user = api_sign_in
+        Fabricate(:keyword, user: user, id: 1)
+        get :show, params: { id: 1 }
+        body = JSON.parse(response.body, symbolize_names: true)
+
+        expect(body[:data][:id]).to eq('1')
+      end
+    end
+
+    context 'given an invalid survey ID' do
+      it 'returns not_found status' do
+        api_sign_in
+        get :show, params: { id: -1 }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -128,26 +128,26 @@ RSpec.describe API::V1::KeywordsController, type: :request do
   end
 
   describe 'GET#show' do
-    context 'given a valid survey ID' do
+    context 'given a valid keyword id' do
       it 'returns success status' do
         user = api_sign_in
-        Fabricate(:keyword, user: user, id: 1)
-        get :show, params: { id: 1 }
+        keyword = Fabricate(:keyword, user: user, id: 1)
+        get :show, params: { id: keyword.id }
 
         expect(response).to have_http_status(:success)
       end
 
       it 'returns the expected keyword' do
         user = api_sign_in
-        Fabricate(:keyword, user: user, id: 1)
-        get :show, params: { id: 1 }
+        keyword = Fabricate(:keyword, user: user, id: 1)
+        get :show, params: { id: keyword.id }
         body = JSON.parse(response.body, symbolize_names: true)
 
         expect(body[:data][:id]).to eq('1')
       end
     end
 
-    context 'given an invalid survey ID' do
+    context 'given an invalid keyword id' do
       it 'returns not_found status' do
         api_sign_in
         get :show, params: { id: -1 }


### PR DESCRIPTION
Resolves #22

## What happened 👀

After the user uploads the keywords file, with each keyword, we need to asynchronous search it on Google, and then show the status and also the report to the user.
 
## Insight 📝

- Create API for getting detail of a keyword
- Endpoint: GET `{base_url}/api/v1/keywords/{id}`
<details>
<summary>Body Example</summary>
{
    "data": {
        "id": "13",
        "type": "keyword",
        "attributes": {
            "keyword": "Sofa",
            "status": "completed",
            "ads_top_count": 0,
            "ads_page_count": 0,
            "non_ads_count": 8,
            "total_links_count": 80,
            "created_at": "2022-01-14T15:00:17.332Z",
            "html":"..."
        },
        "relationships": {
            "links": {
                "data": [
                    {
                        "id": "123",
                        "type": "link"
                    }
                ]
            }
        }
    },
    "included": [
        {
            "id": "123",
            "type": "link",
            "attributes": {
                "url": "https://jysk.vn/sofa-ghe-banh",
                "link_type": "non_ads",
                "created_at": "2022-01-14T15:00:26.839Z"
            }
        }
    ]
}
</details>

 
## Proof Of Work 📹

<img width="1062" alt="Screen Shot 2022-01-14 at 23 46 50" src="https://user-images.githubusercontent.com/19943832/149553593-57accc3a-fc09-415a-a964-db45b1ff6de6.png">

